### PR TITLE
delete should raise KeyError if key to be deleted does not exist

### DIFF
--- a/src/storage/aiodb.py
+++ b/src/storage/aiodb.py
@@ -39,7 +39,9 @@ class AsyncSqliteStore(ObjectStore):
         return (await cursor.fetchone()) is not None
     
     async def delete(self, key):
-        await self.conn.execute('DELETE FROM objects WHERE key = ?', (key,))
+        cursor = await self.conn.execute('DELETE FROM objects WHERE key = ?', (key,))
+        if cursor.rowcount == 0:
+            raise KeyError(key)
         await self.conn.commit()
 
     async def keys(self):

--- a/src/storage/db.py
+++ b/src/storage/db.py
@@ -37,7 +37,9 @@ class SqliteStore(ObjectStore):
         return cursor.fetchone() is not None
     
     def delete(self, key):
-        self.conn.execute('DELETE FROM objects WHERE key = ?', (key,))
+        cursor = self.conn.execute('DELETE FROM objects WHERE key = ?', (key,))
+        if cursor.rowcount == 0:
+            raise KeyError(key)
         self.conn.commit()
 
     def keys(self):

--- a/src/storage/object.py
+++ b/src/storage/object.py
@@ -71,6 +71,8 @@ class DictStore(ObjectStore):
     def delete(self, key):
         if key in self.objects:
             del self.objects[key]
+        else:
+            raise KeyError(key)
 
     def keys(self):
         return self.objects.keys()

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -87,6 +87,11 @@ def test_delete(store):
     with pytest.raises(KeyError):
         store.get(key)
 
+    # Attempting to delete non-existent key should raise KeyError
+    with pytest.raises(KeyError):
+        store.delete(key)
+
+
 def test_update(store):
     """Test updating existing keys"""
     key = "test_update"


### PR DESCRIPTION
This pull request improves error handling for delete operations across different storage backends by ensuring that attempting to delete a non-existent key consistently raises a KeyError. It also adds a corresponding test to verify this behavior.

Error handling improvements:

* Updated `delete` methods in `src/storage/db.py`, `src/storage/aiodb.py`, and `src/storage/object.py` to raise a `KeyError` if the key does not exist when attempting to delete. [[1]](diffhunk://#diff-bd87b639a2308371324b9d91bf258ef0f36bdc1e3d6240c78cf3d044e81d5e16L40-R42) [[2]](diffhunk://#diff-93f632a696d9b47bf5bc056b9052f63eaa66803bcd4f562c74359a8512474cd5L42-R44) [[3]](diffhunk://#diff-e4243ff7082b47008ab273d092c81d9df71259db390be98247faa0dcea6272b1R74-R75)

Testing enhancements:

* Added a test in `tests/test_crud.py` to assert that deleting a non-existent key raises a `KeyError`.